### PR TITLE
Exclude static fields in Any?.toJson()

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <excludedPredefinedLibrary name="db-scheduler-additions/db-scheduler-ui-ktor/.gradle/nodejs/node-v24.3.0-darwin-arm64/lib/node_modules" />
+    <excludedPredefinedLibrary name="db-scheduler-additions/db-scheduler-ui-ktor/build/resources/main/static/scheduler-ui/node_modules" />
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.4.0" />
-  </component>
-</project>

--- a/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/util.kt
+++ b/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/util.kt
@@ -5,6 +5,7 @@ import io.github.osoykan.scheduler.ui.backend.model.TaskDetailsRequestParams
 import io.github.osoykan.scheduler.ui.backend.model.TaskRequestParams
 import io.ktor.server.application.*
 import io.ktor.util.*
+import java.lang.reflect.Modifier
 import java.time.Instant
 
 private val loader = object {}.javaClass.classLoader
@@ -91,7 +92,9 @@ private fun Any?.toJsonVal(): JsonVal = when (this) {
 private fun Any.toComplexObject(): JsonVal = try {
   val kClass = this::class
   val properties = kClass.java.declaredFields
-    .filter { !it.isSynthetic }
+    .filter {
+      !it.isSynthetic && !Modifier.isStatic(it.modifiers)
+    }
     .associate { field ->
       field.isAccessible = true
       field.name to field.get(this).toJsonVal()

--- a/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/util.kt
+++ b/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/util.kt
@@ -1,8 +1,6 @@
 package io.github.osoykan.scheduler.ui.ktor
 
-import io.github.osoykan.scheduler.ui.backend.model.LogRequestParams
-import io.github.osoykan.scheduler.ui.backend.model.TaskDetailsRequestParams
-import io.github.osoykan.scheduler.ui.backend.model.TaskRequestParams
+import io.github.osoykan.scheduler.ui.backend.model.*
 import io.ktor.server.application.*
 import io.ktor.util.*
 import java.lang.reflect.Modifier
@@ -94,8 +92,7 @@ private fun Any.toComplexObject(): JsonVal = try {
   val properties = kClass.java.declaredFields
     .filter {
       !it.isSynthetic && !Modifier.isStatic(it.modifiers)
-    }
-    .associate { field ->
+    }.associate { field ->
       field.isAccessible = true
       field.name to field.get(this).toJsonVal()
     }
@@ -124,19 +121,13 @@ private fun JsonVal.toJsonString(): String = when (this) {
 
   is JsonVal.Obj -> buildString {
     append('{')
-    props
-      .asSequence()
-      .map { (key, value) -> "\"${key.escapeJson()}\":${value.toJsonString()}" }
-      .joinTo(this, separator = ",")
+    props.asSequence().joinTo(this, separator = ",") { (key, value) -> "\"${key.escapeJson()}\":${value.toJsonString()}" }
     append('}')
   }
 
   is JsonVal.Arr -> buildString {
     append('[')
-    items
-      .asSequence()
-      .map { it.toJsonString() }
-      .joinTo(this, separator = ",")
+    items.joinTo(this, separator = ",") { it.toJsonString() }
     append(']')
   }
 }

--- a/db-scheduler-ui-ktor/src/test/kotlin/io/github/osoykan/scheduler/ui/ktor/JsonUtilTest.kt
+++ b/db-scheduler-ui-ktor/src/test/kotlin/io/github/osoykan/scheduler/ui/ktor/JsonUtilTest.kt
@@ -2,6 +2,7 @@ package io.github.osoykan.scheduler.ui.ktor
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
 
 class JsonUtilTest :
   FunSpec({
@@ -282,5 +283,9 @@ class JsonUtilTest :
         Item(1, "Apple"),
         Item(2, "Banana")
       ).toJson() shouldBe """[{"id":1,"name":"Apple"},{"id":2,"name":"Banana"}]"""
+    }
+
+    test("Any?.toJson() works on LocalDateTime") {
+      LocalDateTime.MIN.toJson() shouldBe """"-999999999-01-01T00:00""""
     }
   })


### PR DESCRIPTION
This change ignores static fields during `Any?.toJson()`. Static fields are part of the class, not the instance, so I believe this is correct behaviour.

It also fixes serialization of `LocalDateTime` which keeps static references to min and max values. Because of those static references, the current behaviour fails with StackOverflow (endless recursive loop).

Solves #159 