### PR TITLE
Implement support for context-path

### DIFF
--- a/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/plugin.kt
+++ b/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/plugin.kt
@@ -6,8 +6,10 @@ import com.github.kagkarlsson.scheduler.serializer.Serializer
 import io.github.osoykan.scheduler.ui.backend.listener.ExecutionLogListener
 import io.github.osoykan.scheduler.ui.backend.repository.*
 import io.github.osoykan.scheduler.ui.ktor.routing.configureRouting
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.http.content.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
 /**
@@ -29,10 +31,40 @@ import io.ktor.server.routing.*
  * @param config The UI configuration
  */
 fun Route.dbSchedulerUI(config: DbSchedulerUIConfiguration) {
-  singlePageApplication {
-    filesPath = "/static/db-scheduler"
-    useResources = true
-    applicationRoute = config.routePath
+  if (config.contextPath.isBlank()) {
+    singlePageApplication {
+      filesPath = "/static/db-scheduler"
+      useResources = true
+      applicationRoute = config.routePath
+    }
+
+    return
+  }
+
+  // Load and rewrite the index.html with context path
+  val indexHtml = getResourceAsText("static/db-scheduler/index.html")
+  val rewrittenIndexHtml = rewriteIndexHtmlWithContextPath(indexHtml, config.contextPath)
+
+  val routePathWithoutLeadingSlash = config.routePath.removePrefix("/")
+
+  // Route for the db-scheduler path
+  route(routePathWithoutLeadingSlash) {
+    // Serve the rewritten index.html at the root of the route path
+    get {
+      call.respondText(rewrittenIndexHtml, contentType = ContentType.Text.Html)
+    }
+
+    // Serve index.html explicitly at /index.html path
+    get("index.html") {
+      call.respondText(rewrittenIndexHtml, contentType = ContentType.Text.Html)
+    }
+
+    // Serve static assets via singlePageApplication
+    // This handles the SPA fallback for all other paths under the route
+    singlePageApplication {
+      filesPath = "/static/db-scheduler"
+      useResources = true
+    }
   }
 
   configureRouting(config)
@@ -71,6 +103,17 @@ class DbSchedulerUIConfiguration {
    * Path to the UI, default is `/db-scheduler`
    */
   var routePath: String = "/db-scheduler"
+
+  /**
+   * Context path prefix for the UI.
+   * This can be used when the application is hosted behind a reverse proxy with a path prefix.
+   * It will be injected as `window.CONTEXT_PATH` and used to prefix static asset URLs.
+   * Default is empty string (no prefix).
+   * Example: If your backend is reachable at `https://example.com/my-app`, set this to `"/my-app"`.
+   * Note: This is independent from [routePath]. If both are set, the full path would be
+   * `contextPath + routePath` (e.g., `/my-app/db-scheduler`).
+   */
+  var contextPath: String = ""
 
   /**
    * Show task data in the UI, default is `true`
@@ -127,6 +170,7 @@ class DbSchedulerUIConfiguration {
    */
   fun from(other: DbSchedulerUIConfiguration) {
     this.routePath = other.routePath
+    this.contextPath = other.contextPath
     this.taskData = other.taskData
     this.serializer = other.serializer
     this.enabled = other.enabled

--- a/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/routing/api.kt
+++ b/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/routing/api.kt
@@ -18,7 +18,7 @@ internal fun Route.configureRouting(
   val schedulerProvider = config.scheduler
 
   route(api) {
-    config(config.historyEnabled)
+    config(config.historyEnabled, config.contextPath)
 
     if (config.enabled) {
       val taskService = TaskService(schedulerProvider, caching, config.taskData)

--- a/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/routing/config.kt
+++ b/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/routing/config.kt
@@ -4,8 +4,15 @@ import io.github.osoykan.scheduler.ui.ktor.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
-internal fun Route.config(historyEnabled: Boolean = false) {
+internal fun Route.config(historyEnabled: Boolean = false, contextPath: String = "") {
   get("config") {
-    call.respond(mapOf("historyEnabled" to historyEnabled, "showHistory" to historyEnabled, "configured" to true).toJson())
+    call.respond(
+      mapOf(
+        "historyEnabled" to historyEnabled,
+        "showHistory" to historyEnabled,
+        "configured" to true,
+        "contextPath" to contextPath
+      ).toJson()
+    )
   }
 }

--- a/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/util.kt
+++ b/db-scheduler-ui-ktor/src/main/kotlin/io/github/osoykan/scheduler/ui/ktor/util.kt
@@ -157,6 +157,46 @@ internal fun getResourceAsText(path: String): String = loader
   ?.let { r -> r.bufferedReader().use { it.readText() } }
   ?: ""
 
+/**
+ * Normalizes a path string to ensure it starts with a leading slash and has no trailing slash.
+ * Empty or blank strings return empty string.
+ */
+internal fun normalizeContextPath(path: String): String {
+  if (path.isBlank()) {
+    return ""
+  }
+
+  var normalized = path.trim()
+
+  if (!normalized.startsWith("/")) {
+    normalized = "/" + normalized
+  }
+
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.substring(0, normalized.length - 1)
+  }
+
+  return normalized
+}
+
+/**
+ * Rewrites the index.html to include context-path.js and update asset paths.
+ * This is needed to support serving the UI behind a reverse proxy with a path prefix.
+ */
+internal fun rewriteIndexHtmlWithContextPath(html: String, contextPath: String): String {
+  val normalizedContextPath = normalizeContextPath(contextPath)
+
+  val assetPathPrefix = "$normalizedContextPath/db-scheduler/"
+
+  val contextPathScriptTag = "<script>window.CONTEXT_PATH='$normalizedContextPath';</script>"
+
+  return html
+    // Update links to assets with correct asset path
+    .replace("/db-scheduler/", assetPathPrefix)
+    // Insert context-path script after <head>
+    .replace("<head>", "<head>\n    $contextPathScriptTag")
+}
+
 internal inline fun <reified T> ApplicationCall.receiveParametersTyped(): T {
   val map = parameters.flattenEntries().associateBy { it.first }.mapValues { e -> e.value.second }
   return when (T::class) {

--- a/db-scheduler-ui-ktor/src/test/kotlin/io/github/osoykan/scheduler/ui/ktor/StaticResourcesTests.kt
+++ b/db-scheduler-ui-ktor/src/test/kotlin/io/github/osoykan/scheduler/ui/ktor/StaticResourcesTests.kt
@@ -5,8 +5,45 @@ import io.kotest.matchers.string.shouldContain
 
 class StaticResourcesTests :
   FunSpec({
-    test("should get resource as stream") {
-      val html = getResourceAsText("static/db-scheduler/index.html")
-      html shouldContain "/db-scheduler/assets/index-"
+    test("normalizeContextPath should handle empty string") {
+      normalizeContextPath("") shouldContain ""
+    }
+
+    test("normalizeContextPath should handle blank string") {
+      normalizeContextPath("   ") shouldContain ""
+    }
+
+    test("normalizeContextPath should add leading slash") {
+      normalizeContextPath("my-app") shouldContain "/my-app"
+    }
+
+    test("normalizeContextPath should remove trailing slash") {
+      normalizeContextPath("/my-app/") shouldContain "/my-app"
+    }
+
+    test("normalizeContextPath should handle already normalized path") {
+      normalizeContextPath("/my-app") shouldContain "/my-app"
+    }
+
+    test("normalizeContextPath should handle path with both issues") {
+      normalizeContextPath("my-app/") shouldContain "/my-app"
+    }
+
+    test("rewriteIndexHtmlWithContextPath should inject script tag") {
+      val html = "<html><head></head><body></body></html>"
+      val rewritten = rewriteIndexHtmlWithContextPath(html, "/my-app")
+      rewritten shouldContain "<script>window.CONTEXT_PATH='/my-app';</script>"
+    }
+
+    test("rewriteIndexHtmlWithContextPath should update asset paths") {
+      val html = "<script src='/db-scheduler/assets/test.js'></script>"
+      val rewritten = rewriteIndexHtmlWithContextPath(html, "/my-app")
+      rewritten shouldContain "/my-app/db-scheduler/assets/test.js"
+    }
+
+    test("rewriteIndexHtmlWithContextPath should update favicon path") {
+      val html = "<link href='/db-scheduler/favicon.svg' rel='icon' />"
+      val rewritten = rewriteIndexHtmlWithContextPath(html, "/my-app")
+      rewritten shouldContain "/my-app/db-scheduler/favicon.svg"
     }
   })


### PR DESCRIPTION
This fixes #161 

If `contextPath` is set, `index.html` will be rewritten to include the prefix and set `windows.CONTEXT_PATH`.

I believe this is similar in approach as the spring-boot based project.